### PR TITLE
Fixed mnemonics bugs

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,27 +1,25 @@
 [
     {
         "caption": "Tools",
-        "mnemonic": "T",
         "id": "tools",
+        "mnemonic": "t",
         "children":
         [
             {
                 "caption": "Doi9t's packages",
-                "mnemonic": "d",
                 "id": "menu_doi9t",
+                "mnemonic": "o",
                 "children":
                 [
 
                     {
                         "caption": "SortBy",
-                        "mnemonic": "s",
                         "id": "menu_doi9t_sb",
                         "children":
                         [
 
                             {
                             "caption": "Strings",
-                            "mnemonic": "s",
                             "id": "menu_doi9t_sb_str",
                             "children":
                             [
@@ -55,7 +53,6 @@
                             },
                             {
                             "caption": "Numbers",
-                            "mnemonic": "n",
                             "id": "menu_doi9t_sb_num",
                             "children":
                             [


### PR DESCRIPTION
I noticed that I constantly get errors in the console:

    warning: mnemonic d not found in menu caption Doi9t's packages
    warning: mnemonic s not found in menu caption SortBy
    warning: mnemonic n not found in menu caption Numbers

Not unwrap children elements if I select mnemonic key `d`.

![Bug Main.sublime-menu](http://i.imgur.com/oMvl05R.gif)

I correct this bug.

![Correct Main.sublime-menu](http://i.imgur.com/B5FVk0F.gif)

But I select mnemonic key `o` for SortBy, not `d`, because users can not select `Developer` via mnemonics, if mnemonic `d` bind for SortBy. 

Thanks.