### PR TITLE
Fix mnemonic for Tools

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -2,7 +2,7 @@
     {
         "caption": "Tools",
         "id": "tools",
-        "mnemonic": "t",
+        "mnemonic": "T",
         "children":
         [
             {


### PR DESCRIPTION
The mnemonics are case sensitive and this produces the warning `warning: mnemonic t not found in menu caption Tools` in the console.

Bug introduced by #15