### PR TITLE
Correctly use Github Markdown for Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,35 @@
-##SortBy
-<sup>*A Sublime Text plugin that allows you to sort lines with methods that are not presents by default.*</sup>
+# SortBy
+*A Sublime Text plugin that allows you to sort lines with methods that are not present by default.*
 - - -
-
-**Sorting methods available:**
-~~~
+​
+## Sorting methods available:
 - Natural order
 - Sort by the length of lines (Ascending / Descending)
-	-Can be sorted alphabetically (Ascending / Descending) (Editable in SortBy.sublime-settings)
+    - Can be sorted alphabetically (Ascending / Descending) (Editable in SortBy.sublime-settings)
 - Sort lines of text alphabetically (Ascending / Descending)
 - Sort numbers numerically with and without surrounding caracters (Ascending / Descending)
     1. Binary
     2. Hexadecimal
     3. Integer
     4. Octal
-~~~
 
-<br/>
-**Features availables:**
-~~~
+## Features availables:
 1. Able to sort the entire file (when there is no selection)
 2. Case sensitivity option for the alphabetically sort (Editable in SortBy.sublime-settings)
-~~~
 
-<br/>
-**Manual installation:**
-~~~
-1) Find your local Sublime Text [2 or 3] Packages directory.
-Example : C:\Users\USER_NAME\AppData\Roaming\Sublime Text [2 or 3]\Packages
+## Manual installation:
+1. Find your local Sublime Text [2 or 3] Packages directory.
+    Example: `C:\Users\USER_NAME\AppData\Roaming\Sublime Text [2 or 3]\Packages`
+2. Copy the SortBy directory inside the Packages directory.
+3. Restart Sublime Text and enjoy !
 
-2) Copy the SortBy directory inside the Packages directory.
+## How to use:
+1. Select the text you want to sort.
+2. Go in the menu "Tools", "Doi9t's packages" then you should see "SortBy".
+3. Choose your option. (Either Reverse or normal).
 
-3) Restart Sublime Text and enjoy !
-~~~
-
-<br/>
-**How to use:**
-~~~
-1) Select the text you want to sort.
-
-2) Go in the menu "Tools", "Doi9t's packages" then you should see "SortBy".
-
-3) Choose your option. (Either Reverse or normal).
-~~~
-
-<br>Or using the control palette.
-<br><kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on Windows/Linux.
-<br><kbd>COMMAND</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on OS X.
+Or using the control palette
+<br><kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on *Windows/Linux*.
+<br><kbd>COMMAND</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on *OS X*.
 <br>and type SortBy in the box.
+​


### PR DESCRIPTION
I don't know what style of Markdown is in use in the Readme but it seems that it is rendered incorrectly on Github.

Changed the Readme so that it renders pleasantly and fixed one typo.